### PR TITLE
Scope's `FullScreenPresentable` protocol to `iOS`.

### DIFF
--- a/AEPTarget/Sources/Preview/PreviewManager.swift
+++ b/AEPTarget/Sources/Preview/PreviewManager.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPCore
 import AEPServices
 import Foundation
@@ -59,3 +59,4 @@ protocol PreviewManager {
     ///
     var previewToken: String? { get }
 }
+#endif


### PR DESCRIPTION
Makes `FullScreenPresentable` protocol available on iOS.