### PR TITLE
Marks all `AEPTarget` source files as available to iOS only.

### DIFF
--- a/AEPTarget/Sources/Dictionary+Target.swift
+++ b/AEPTarget/Sources/Dictionary+Target.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import Foundation
 
 extension Dictionary where Key == String, Value == Any {
@@ -28,3 +28,4 @@ extension Dictionary where Key == String, Value == Any {
         return dictionary.merging(newDictionary) { _, new in new }
     }
 }
+#endif

--- a/AEPTarget/Sources/Event+Target.swift
+++ b/AEPTarget/Sources/Event+Target.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPCore
 import Foundation
 
@@ -101,3 +101,4 @@ extension Event {
         return try? JSONDecoder().decode(T.self, from: jsonData)
     }
 }
+#endif

--- a/AEPTarget/Sources/Preview/TargetPreviewManager.swift
+++ b/AEPTarget/Sources/Preview/TargetPreviewManager.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPCore
 import AEPServices
 import Foundation
@@ -238,3 +238,4 @@ class TargetPreviewManager: PreviewManager {
         return Event(name: "Target Preview Lifecycle", type: EventType.target, source: EventSource.responseContent, data: eventData)
     }
 }
+#endif

--- a/AEPTarget/Sources/Preview/TargetPreviewManagerFloatingButtonDelegate.swift
+++ b/AEPTarget/Sources/Preview/TargetPreviewManagerFloatingButtonDelegate.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPServices
 
 ///
@@ -26,3 +26,4 @@ extension TargetPreviewManager: FloatingButtonDelegate {
 
     func onPanDetected() {}
 }
+#endif

--- a/AEPTarget/Sources/Preview/TargetPreviewManagerFullscreenMessageDelegate.swift
+++ b/AEPTarget/Sources/Preview/TargetPreviewManagerFullscreenMessageDelegate.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPCore
 import AEPServices
 import Foundation
@@ -45,3 +45,4 @@ extension TargetPreviewManager: FullscreenMessageDelegate {
         return true
     }
 }
+#endif

--- a/AEPTarget/Sources/Target+PublicAPI.swift
+++ b/AEPTarget/Sources/Target+PublicAPI.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPCore
 import AEPServices
 import Foundation
@@ -463,3 +463,4 @@ import Foundation
         MobileCore.dispatch(event: event)
     }
 }
+#endif

--- a/AEPTarget/Sources/Target.swift
+++ b/AEPTarget/Sources/Target.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPCore
 import AEPServices
 import Foundation
@@ -1172,3 +1172,4 @@ public class Target: NSObject, Extension {
         return responsePayload.isEmpty ? nil : responsePayload
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetConstants.swift
+++ b/AEPTarget/Sources/TargetConstants.swift
@@ -321,3 +321,4 @@ enum TargetConstants {
         static let CONNECTION_RESPONSE_MESSAGE_NO_ERROR = "no error"
     }
 }
+

--- a/AEPTarget/Sources/TargetDeliveryRequest.swift
+++ b/AEPTarget/Sources/TargetDeliveryRequest.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import AEPServices
 import Foundation
 
@@ -233,3 +234,4 @@ struct Order: Codable {
 struct Property: Codable {
     var token: String?
 }
+#endif

--- a/AEPTarget/Sources/TargetDeliveryRequestBuilder.swift
+++ b/AEPTarget/Sources/TargetDeliveryRequestBuilder.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPServices
 import Foundation
 
@@ -244,3 +244,4 @@ enum TargetDeliveryRequestBuilder {
         return nil
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetDeliveryResponse.swift
+++ b/AEPTarget/Sources/TargetDeliveryResponse.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import Foundation
 
 /// Struct to represent Target Delivery API call JSON response.
@@ -73,4 +73,4 @@ enum TargetResponseConstants {
         // ---- execute - mboxes - mbox -----
     }
 }
-
+#endif

--- a/AEPTarget/Sources/TargetDeliveryResponse.swift
+++ b/AEPTarget/Sources/TargetDeliveryResponse.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 /// Struct to represent Target Delivery API call JSON response.
@@ -72,3 +73,4 @@ enum TargetResponseConstants {
         // ---- execute - mboxes - mbox -----
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetDeliveryResponse.swift
+++ b/AEPTarget/Sources/TargetDeliveryResponse.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-#if os(iOS)
+
 import Foundation
 
 /// Struct to represent Target Delivery API call JSON response.
@@ -73,4 +73,4 @@ enum TargetResponseConstants {
         // ---- execute - mboxes - mbox -----
     }
 }
-#endif
+

--- a/AEPTarget/Sources/TargetError.swift
+++ b/AEPTarget/Sources/TargetError.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import Foundation
 
 class TargetError: Error, CustomStringConvertible {
@@ -47,3 +47,4 @@ class TargetError: Error, CustomStringConvertible {
         message
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetOrder+Internal.swift
+++ b/AEPTarget/Sources/TargetOrder+Internal.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 extension TargetOrder {
@@ -26,3 +27,4 @@ extension TargetOrder {
         return try? JSONDecoder().decode(TargetOrder.self, from: jsonData)
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetOrder.swift
+++ b/AEPTarget/Sources/TargetOrder.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 /// Class for specifying Target order parameters
@@ -29,3 +30,4 @@ public class TargetOrder: NSObject, Codable {
         self.purchasedProductIds = purchasedProductIds
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetParameters+Internal.swift
+++ b/AEPTarget/Sources/TargetParameters+Internal.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 extension TargetParameters {
@@ -22,3 +23,4 @@ extension TargetParameters {
         return try? JSONDecoder().decode(TargetParameters.self, from: jsonData)
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetParameters.swift
+++ b/AEPTarget/Sources/TargetParameters.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 /// Target parameter class, used for specifying custom parameters to be sent in Target requests,
@@ -33,3 +34,4 @@ public class TargetParameters: NSObject, Codable {
         self.product = product
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetPrefetch+Internal.swift
+++ b/AEPTarget/Sources/TargetPrefetch+Internal.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 extension TargetPrefetch {
@@ -38,3 +39,4 @@ extension TargetPrefetch {
         return prefetches
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetPrefetch.swift
+++ b/AEPTarget/Sources/TargetPrefetch.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 /// `TargetPrefetch` class, used for specifying a mbox location.
@@ -26,3 +27,4 @@ public class TargetPrefetch: NSObject, Codable {
         self.targetParameters = targetParameters
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetProduct+Internal.swift
+++ b/AEPTarget/Sources/TargetProduct+Internal.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import Foundation
 
 extension TargetProduct {
@@ -29,3 +29,4 @@ extension TargetProduct {
         return try? JSONDecoder().decode(TargetProduct.self, from: jsonData)
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetProduct.swift
+++ b/AEPTarget/Sources/TargetProduct.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 /// Class for specifying Target product parameters
@@ -26,3 +27,4 @@ public class TargetProduct: NSObject, Codable {
         self.categoryId = categoryId
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetRequest+Internal.swift
+++ b/AEPTarget/Sources/TargetRequest+Internal.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 
 extension TargetRequest {
@@ -38,3 +39,4 @@ extension TargetRequest {
         return requests
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetRequest.swift
+++ b/AEPTarget/Sources/TargetRequest.swift
@@ -9,6 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
+#if os(iOS)
 import Foundation
 @objc(AEPTargetRequestObject)
 public class TargetRequest: NSObject, Codable {
@@ -56,3 +57,4 @@ public class TargetRequest: NSObject, Codable {
         case responsePairId
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetState.swift
+++ b/AEPTarget/Sources/TargetState.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPServices
 import Foundation
 
@@ -241,3 +241,4 @@ class TargetState {
         return (currentTimestamp - sessionTimestamp) > sessionTimeoutInSeconds
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetV4Migrator.swift
+++ b/AEPTarget/Sources/TargetV4Migrator.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPServices
 import Foundation
 
@@ -57,3 +57,4 @@ enum TargetV4Migrator {
         Log.trace(label: Target.LOG_TAG, "Target V4 data migration completed.")
     }
 }
+#endif

--- a/AEPTarget/Sources/TargetV5Migrator.swift
+++ b/AEPTarget/Sources/TargetV5Migrator.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import AEPServices
 import Foundation
 
@@ -57,3 +57,4 @@ enum TargetV5Migrator {
         Log.trace(label: Target.LOG_TAG, "Target V5 data migration completed.")
     }
 }
+#endif

--- a/AEPTarget/Sources/URL+Target.swift
+++ b/AEPTarget/Sources/URL+Target.swift
@@ -9,7 +9,7 @@
  OF ANY KIND, either express or implied. See the License for the specific language
  governing permissions and limitations under the License.
  */
-
+#if os(iOS)
 import Foundation
 
 ///
@@ -56,3 +56,4 @@ extension URL {
         }
     }
 }
+#endif


### PR DESCRIPTION
This prevents a multi-platform consumer of `AEPTarget` in a shared package from attempting to compile the included files.